### PR TITLE
Add SourceContext in SeriLog outputTemplate to write logger category in ...

### DIFF
--- a/samples/SignalRSample.Web/Startup.cs
+++ b/samples/SignalRSample.Web/Startup.cs
@@ -12,9 +12,11 @@ namespace SignalRSample.Web
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
 #if ASPNET50
+            string OutputTemplate = "{SourceContext} {Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
+
             var serilog = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
-                .WriteTo.RollingFile(@".\SignalR-Log-{Date}.txt");
+                .WriteTo.RollingFile(@".\SignalR-Log-{Date}.txt", outputTemplate: OutputTemplate);
 
             loggerFactory.AddSerilog(serilog);
 #endif


### PR DESCRIPTION
Add SourceContext in SeriLog outputTemplate to write logger category in logs