### PR TITLE
Enable adding scale-out service only if chain to AddSignalR

### DIFF
--- a/test/Microsoft.AspNet.SignalR.Server.Tests/Hubs/HubDispatcherFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Server.Tests/Hubs/HubDispatcherFacts.cs
@@ -228,6 +228,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Hubs
                 .AddHosting()
                 .AddDataProtection()
                 .AddSignalR()
+                .ServiceCollection
                 .AddInstance<IHubManager>(mockHubManager.Object)
                 .BuildServiceProvider();
 

--- a/test/Microsoft.AspNet.SignalR.Server.Tests/Hubs/TypedClientBuilderFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Server.Tests/Hubs/TypedClientBuilderFacts.cs
@@ -129,6 +129,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Hubs
                 .AddOptions()
                 .AddDataProtection()
                 .AddSignalR()
+                .ServiceCollection
                 .BuildServiceProvider();
 
             var manager = serviceProvider.GetRequiredService<IConnectionManager>();

--- a/test/Microsoft.AspNet.SignalR.Server.Tests/Infrastructure/ServiceProviderHelper.cs
+++ b/test/Microsoft.AspNet.SignalR.Server.Tests/Infrastructure/ServiceProviderHelper.cs
@@ -27,9 +27,9 @@ namespace Microsoft.AspNet.SignalR.Tests
                 .AddDataProtection()
                 .AddSignalR();
 
-            configure(collection);
+            configure(collection.ServiceCollection);
 
-            return collection.BuildServiceProvider();
+            return collection.ServiceCollection.BuildServiceProvider();
         }
     }
 }

--- a/test/Microsoft.AspNet.SignalR.Server.Tests/MessageBusFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Server.Tests/MessageBusFacts.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.KeepAlive = null;
                 });
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.KeepAlive = null;
                 });
@@ -159,7 +159,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.DisconnectTimeout = TimeSpan.FromSeconds(6);
                 });
@@ -227,7 +227,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.DisconnectTimeout = TimeSpan.FromSeconds(6);
                     options.Transports.KeepAlive = null;
@@ -326,7 +326,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.DisconnectTimeout = TimeSpan.FromSeconds(6);
                     options.Transports.KeepAlive = null;
@@ -356,7 +356,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.Transports.DisconnectTimeout = TimeSpan.FromSeconds(6);
                     options.Transports.KeepAlive = null;

--- a/test/Microsoft.AspNet.SignalR.Server.Tests/ScaleOutMessageBusFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Server.Tests/ScaleOutMessageBusFacts.cs
@@ -188,7 +188,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.MessageBus.MessageBufferSize = 10;
                 });
@@ -243,7 +243,7 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             var sp = ServiceProviderHelper.CreateServiceProvider(services =>
             {
-                services.ConfigureSignalR(options =>
+                services.AddSignalR(options =>
                 {
                     options.MessageBus.MessageBufferSize = 10;
                 });


### PR DESCRIPTION
e.g. In Startup, enable AddSqlServer only when chain to AddSignalR, it only allow SignalR services chain to AddSignalR:
```csharp
            app.UseServices(services =>
            {
                services.AddSignalR(options =>
                        {
                            options.Hubs.EnableDetailedErrors = true;
                        })
                        .AddSqlServer(options =>
                        {
                            options.ConnectionString = "<connection string>";
                        });
            });
```
Note, verified the related tests passed with the change in SignalR-Server..