### PR TITLE
Add UseStatusCodePages in the sample project

### DIFF
--- a/samples/SignalRSample.Web/Startup.cs
+++ b/samples/SignalRSample.Web/Startup.cs
@@ -19,6 +19,7 @@ namespace SignalRSample.Web
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             app.UseFileServer();
+            app.UseStatusCodePages();
 
             app.UseSignalR<RawConnection>("/raw-connection");
             app.UseSignalR();

--- a/samples/SignalRSample.Web/project.json
+++ b/samples/SignalRSample.Web/project.json
@@ -4,6 +4,7 @@
         "Microsoft.AspNet.Server.IIS": "1.0.0-*",
         "Microsoft.AspNet.Server.WebListener": "1.0.0-*",
         "Microsoft.AspNet.StaticFiles": "1.0.0-*",
+        "Microsoft.AspNet.Diagnostics": "1.0.0-*",
         "Microsoft.AspNet.SignalR.Server": "3.0.0-*"
     },
     "commands": {


### PR DESCRIPTION
An empty page is not the best way to tell that you have reached a 404 in the samples (of which there is a few as it appears many are not implemented yet). By simply using the UseStatusCodePages() from Diagnostics at least something is shown when poking around the samples and it is clear that a HTTP error status has been returned.
