### PR TITLE
Reacting to verbose rename

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Messaging/ScaleoutStream.cs
+++ b/src/Microsoft.AspNet.SignalR.Messaging/ScaleoutStream.cs
@@ -305,14 +305,17 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 case LogLevel.Error:
                     _logger.LogError(String.Format(value, args));
                     break;
+                case LogLevel.Warning:
+                    _logger.LogWarning(String.Format(value, args));
+                    break;
                 case LogLevel.Information:
                     _logger.LogInformation(String.Format(value, args));
                     break;
-                case LogLevel.Verbose:
-                    _logger.LogVerbose(String.Format(value, args));
+                case LogLevel.Debug:
+                    _logger.LogDebug(String.Format(value, args));
                     break;
-                case LogLevel.Warning:
-                    _logger.LogWarning(String.Format(value, args));
+                case LogLevel.Trace:
+                    _logger.LogTrace(String.Format(value, args));
                     break;
                 default:
                     break;

--- a/src/Microsoft.AspNet.SignalR.Server/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Server/Transports/ForeverTransport.cs
@@ -244,7 +244,7 @@ namespace Microsoft.AspNet.SignalR.Transports
         {
             var context = (ForeverTransportContext)state;
 
-            context.Transport.Logger.LogVerbose("Cancel(" + context.Transport.ConnectionId + ")");
+            context.Transport.Logger.LogDebug("Cancel(" + context.Transport.ConnectionId + ")");
 
             ((IDisposable)context.State).Dispose();
         }

--- a/src/Microsoft.AspNet.SignalR.Server/Transports/HttpRequestLifeTime.cs
+++ b/src/Microsoft.AspNet.SignalR.Server/Transports/HttpRequestLifeTime.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         public void Complete(Exception error)
         {
-            _logger.LogVerbose("DrainWrites(" + _connectionId + ")");
+            _logger.LogDebug("DrainWrites(" + _connectionId + ")");
 
             var context = new LifetimeContext(_transport, _lifetimeTcs, error);
 

--- a/src/Microsoft.AspNet.SignalR.Server/Transports/TransportHeartBeat.cs
+++ b/src/Microsoft.AspNet.SignalR.Server/Transports/TransportHeartBeat.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.SignalR.Transports
 
             _connections.AddOrUpdate(connection.ConnectionId, newMetadata, (key, old) =>
             {
-                Logger.LogVerbose(String.Format("Connection {0} exists. Closing previous connection.", old.Connection.ConnectionId));
+                Logger.LogDebug(String.Format("Connection {0} exists. Closing previous connection.", old.Connection.ConnectionId));
                 // Kick out the older connection. This should only happen when 
                 // a previous connection attempt fails on the client side (e.g. transport fallback).
 
@@ -172,7 +172,7 @@ namespace Microsoft.AspNet.SignalR.Transports
         {
             if (Interlocked.Exchange(ref _running, 1) == 1)
             {
-                Logger.LogVerbose("Timer handler took longer than current interval");
+                Logger.LogDebug("Timer handler took longer than current interval");
                 return;
             }
 
@@ -193,7 +193,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                     }
                     else
                     {
-                        Logger.LogVerbose(metadata.Connection.ConnectionId + " is dead");
+                        Logger.LogDebug(metadata.Connection.ConnectionId + " is dead");
 
                         // Check if we need to disconnect this connection
                         CheckDisconnect(metadata);
@@ -224,7 +224,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                 // of us handling timeout's or disconnects gracefully
                 if (RaiseKeepAlive(metadata))
                 {
-                    Logger.LogVerbose("KeepAlive(" + metadata.Connection.ConnectionId + ")");
+                    Logger.LogDebug("KeepAlive(" + metadata.Connection.ConnectionId + ")");
 
                     // Ensure delegate continues to use the C# Compiler static delegate caching optimization.
                     metadata.Connection.KeepAlive().Catch((ex, state) => OnKeepAliveError(ex, state), state: Logger, logger: Logger);


### PR DESCRIPTION
Reacting to https://github.com/aspnet/Logging/pull/314.
Built locally. Should update the tests to run when running `./build{.cmd/.sh}` though.