### PR TITLE
prevent AckSubscriber from throwing NotSupportedException on Dispose

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Server/Infrastructure/AckSubscriber.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Server/Infrastructure/AckSubscriber.cs
@@ -17,11 +17,10 @@ namespace Microsoft.AspNetCore.SignalR.Infrastructure
     {
         private readonly IMessageBus _messageBus;
         private readonly IAckHandler _ackHandler;
+        private readonly List<string> _signals = new List<string>(1) { Signal };
         private IDisposable _subscription;
 
         private const int MaxMessages = 10;
-
-        private static readonly string[] ServerSignals = new[] { Signal };
 
         public AckSubscriber(IMessageBus messageBus, IAckHandler ackHandler)
         {
@@ -38,7 +37,7 @@ namespace Microsoft.AspNetCore.SignalR.Infrastructure
 
         public IList<string> EventKeys
         {
-            get { return ServerSignals; }
+            get { return _signals; }
         }
 
         public event Action<ISubscriber, string> EventKeyAdded


### PR DESCRIPTION
**The problem:** calling `AckSubscriber.Dispose` throws `NotSupportedException`. (I get this when I am disposing my dependency injection container in my ASP.NET Core app).

**Reason:** `Subscription` calls `EventKeys.Remove(key)` in it's `Dispose` implementation.  `Subscription` can be created with `IList<string> eventKeys`, which can be an array.  Array does not support Remove and throws `NotSupportedException` when called. `AckSubscriber` [returns array](https://github.com/aspnet/SignalR-Server/blob/623bd9fdf339da2990e6c75f3dbc6a9e2fa2499f/src/Microsoft.AspNetCore.SignalR.Server/Infrastructure/AckSubscriber.cs#L41) in it's `ISubscriber` implementation. So it's Dispose always throws.
