### PR TITLE
Groups not working with js client and longPolling transport

### DIFF
--- a/src/Microsoft.AspNetCore.SignalR.Server/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNetCore.SignalR.Server/Transports/LongPollingTransport.cs
@@ -108,7 +108,7 @@ namespace Microsoft.AspNetCore.SignalR.Transports
         {
             var groupsToken = Context.Request.Query["groupsToken"];
 
-            if (groupsToken.Count > 0 && Context.Request.HasFormContentType)
+            if (groupsToken.Count == 0 && Context.Request.HasFormContentType)
             {
                 var form = await Context.Request.ReadFormAsync().PreserveCulture();
                 groupsToken = form["groupsToken"];

--- a/test/Microsoft.AspNetCore.SignalR.Messaging.Tests/Microsoft.AspNetCore.SignalR.Messaging.Tests.xproj
+++ b/test/Microsoft.AspNetCore.SignalR.Messaging.Tests/Microsoft.AspNetCore.SignalR.Messaging.Tests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.AspNetCore.SignalR.Server.Tests/Microsoft.AspNetCore.SignalR.Server.Tests.xproj
+++ b/test/Microsoft.AspNetCore.SignalR.Server.Tests/Microsoft.AspNetCore.SignalR.Server.Tests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
js client is sending groupsToken in the message body and it was not read correctly.

Fixes: #178