### PR TITLE
add some diagnostics to compat tests

### DIFF
--- a/test/Microsoft.AspNetCore.SignalR.CompatTests/ChatHubTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.CompatTests/ChatHubTests.cs
@@ -71,8 +71,8 @@ namespace Microsoft.AspNetCore.SignalR.CompatTests
 
                 AssertMessage("client1", "Hello, World!", await client2.WaitForMessage());
                 AssertMessage("client1", "Hello, World!", await client4.WaitForMessage());
-                Assert.False(client1.HasMessage());
-                Assert.False(client3.HasMessage());
+                AssertNoMessage(client1);
+                AssertNoMessage(client3);
             }
         }
 
@@ -129,6 +129,15 @@ namespace Microsoft.AspNetCore.SignalR.CompatTests
         {
             Assert.Equal(from, msg.From);
             Assert.Equal(message, msg.Message);
+        }
+
+        private void AssertNoMessage(ChatHubTestClient client)
+        {
+            if (client.HasMessage())
+            {
+                var message = client.WaitForMessage().Result;
+                Assert.False(true, $"Expected the client to not have received any message, but instead it has received a message from '{message.From}' containing '{message.Message}'");
+            }
         }
     }
 }

--- a/test/Microsoft.AspNetCore.SignalR.CompatTests/PersistentConnectionTests.cs
+++ b/test/Microsoft.AspNetCore.SignalR.CompatTests/PersistentConnectionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -58,8 +59,8 @@ namespace Microsoft.AspNetCore.SignalR.CompatTests
 
                 AssertMessage(client1.Connection.ConnectionId, "Hello, World!", await client2.WaitForMessage());
                 AssertMessage(client1.Connection.ConnectionId, "Hello, World!", await client4.WaitForMessage());
-                Assert.False(client1.HasMessage());
-                Assert.False(client3.HasMessage());
+                AssertNoMessage(client1);
+                AssertNoMessage(client3);
             }
         }
 
@@ -105,6 +106,15 @@ namespace Microsoft.AspNetCore.SignalR.CompatTests
             Assert.Equal(MessageType.Message, message.Type);
             Assert.Equal(from, message.SourceOrDest);
             Assert.Equal(value, message.Value);
+        }
+
+        private void AssertNoMessage(TestConnectionClient client)
+        {
+            if (client.HasMessage())
+            {
+                var message = client.WaitForMessage().Result;
+                Assert.False(true, $"Expected the client to not have received any message, but instead it has received a '{message.Type}' message containing '{message.Value}' from '{message.SourceOrDest}'");
+            }
         }
     }
 }


### PR DESCRIPTION
We got a random failure in these tests on the CI and I don't know why (since it's not something that should be flaky). I'm adding a little more descriptive reporting to that test to help track it down when it happens again.